### PR TITLE
Improve appearance and behavior of mascot

### DIFF
--- a/src/components/MascotItem.vue
+++ b/src/components/MascotItem.vue
@@ -1,9 +1,14 @@
 <template>
-  <div v-if="mascot.showMascot" @click="mascot.readMessageAgain" class="mascot-container">
+  <div
+    @click="mascot.readMessageAgain"
+    :class="quizAppearance ? 'mascot-container-quiz' : 'mascot-container-default'"
+  >
     <transition name="appear">
-      <!--TODO: add transition-->
-      <div v-if="mascot.speechBubbleShown" class="speech-bubble">
-        <p>{{ mascot.messageString }}</p>
+      <div
+        v-if="mascot.speechBubbleShown"
+        :class="quizAppearance ? 'speech-bubble-quiz' : 'speech-bubble-default'"
+      >
+        <p>{{ mascot.currentMessageString }}</p>
       </div>
     </transition>
     <img src="../assets/mascot/Max_happy.svg" alt="Max_happy" />
@@ -13,46 +18,58 @@
 <script setup lang="ts">
 import { useMascotStore } from '@/stores/useMascotStore'
 const mascot = useMascotStore()
+
+defineProps<{
+  quizAppearance: Boolean
+}>()
 </script>
 
 <style scoped lang="scss">
-.mascot-container {
+@mixin mascot-container($flex-direction, $align-items) {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  flex-direction: $flex-direction;
+  align-items: $align-items;
   -webkit-tap-highlight-color: transparent;
+
   img {
     width: 150px;
   }
 }
-.speech-bubble {
+@mixin speech-bubble($max-width, $margin-right) {
   position: relative;
-  max-width: 300px;
+  max-width: $max-width;
   padding: 20px;
   margin-bottom: 20px;
-  color: black;
-  background-color: #e1efc8;
-  border: 2px solid #324e00;
-  border-radius: 10px;
+  margin-right: $margin-right;
+  background: var(--s40-color-primary);
+  border: 3px solid #3a3e56;
+  border-radius: 30px 30px 3px 30px;
 
   p {
     //TODO: use design system
+    color: white;
     -webkit-user-select: none;
     user-select: none;
     font-size: 25px;
   }
+}
 
-  &:after {
-    border: 1em solid transparent;
-    border-top-color: #e1efc8;
-    content: '';
-    margin-left: -1em;
-    position: absolute;
-    top: 100%;
-    left: 87%;
-    width: 0;
-    height: 0;
-  }
+.mascot-container-default {
+  @include mascot-container(column, flex-end);
+}
+
+.mascot-container-quiz {
+  @include mascot-container(row, flex-start);
+  justify-content: flex-end;
+  width: 900px;
+}
+
+.speech-bubble-default {
+  @include speech-bubble(300px, 50px);
+}
+
+.speech-bubble-quiz {
+  @include speech-bubble(700px, 20px);
 }
 
 .appear-enter-active {

--- a/src/composables/reading.ts
+++ b/src/composables/reading.ts
@@ -15,17 +15,21 @@ export function useReading() {
   speech.pitch = 1.3
 
   const audio = new Audio()
+  let nextAction: Function
 
-  function hideSpeechBubble() {
+  function onSpeechEnd() {
     const mascot = useMascotStore() //TODO: initialize mascot store outside this function
     setTimeout(() => {
       if (audio.paused && !window.speechSynthesis.speaking) {
         mascot.hideSpeechBubble()
       }
+      if (nextAction) {
+        nextAction()
+      }
     }, 1500)
   }
 
-  audio.addEventListener('ended', hideSpeechBubble)
+  audio.addEventListener('ended', onSpeechEnd)
 
   function cancelAudio() {
     window.speechSynthesis.cancel()
@@ -45,12 +49,15 @@ export function useReading() {
     if (audio.paused) {
       window.speechSynthesis.speak(speech)
     }
-    speech.onend = () => hideSpeechBubble()
+    speech.onend = () => onSpeechEnd()
   }
 
-  async function readAloud(key: StringResourceKey) {
+  async function readAloud(key: StringResourceKey, onEnd?: Function) {
     const filePath = `/src/assets/audio/mascot/${key}.mp3`
     cancelAudio()
+    if (onEnd) {
+      nextAction = onEnd //define follow up action
+    }
 
     try {
       //check if file exists

--- a/src/stores/useMascotStore.ts
+++ b/src/stores/useMascotStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import type { Message, StringResourceKey } from '@/config/mascotMessages'
+import type { StringResourceKey } from '@/config/mascotMessages'
 import { getStringRes } from '@/config/mascotMessages'
 import { useReading } from '@/composables/reading'
 
@@ -9,33 +9,30 @@ export const useMascotStore = defineStore('popup', {
   state: () => ({
     showMascot: false,
     speechBubbleShown: false,
-    messageKey: '' as StringResourceKey
+    messageKey: '' as StringResourceKey,
+    defaultPosition: true
   }),
   getters: {
-    messageString: (state) => {
+    currentMessageString: (state) => {
       return getStringRes(state.messageKey).content
     }
   },
   actions: {
-    /** @deprecated
-     * use showMessage(key: StringResourceKey, delay?: number) instead
-     */
-    setMessage(message: Message) {
-      console.log(message.content)
-    },
-    showMessage(key: StringResourceKey, delay?: number) {
+    showMessage(key: StringResourceKey, onEnd?: Function, overrideDefaultPosition = false) {
+      this.defaultPosition = !overrideDefaultPosition
       this.hideSpeechBubble() //Support animation
       this.showMascotItem()
-      setTimeout(() => {
-        this.showSpeechBubble()
-        this.messageKey = key
-        this.readMessage()
-      }, delay)
+
+      this.showSpeechBubble()
+
+      this.messageKey = key
+      this.readMessage(onEnd)
     },
-    showMascotItem(delay?: number) {
-      setTimeout(() => {
-        this.showMascot = true
-      }, delay)
+    getMessageString: (key: StringResourceKey) => {
+      return getStringRes(key).content
+    },
+    showMascotItem() {
+      this.showMascot = true
     },
     hideMascotItem() {
       this.showMascot = false
@@ -50,8 +47,8 @@ export const useMascotStore = defineStore('popup', {
       this.showSpeechBubble()
       this.readMessage()
     },
-    readMessage() {
-      readAloud(this.messageKey)
+    readMessage(onEnd?: Function) {
+      readAloud(this.messageKey, onEnd)
     }
   }
 })

--- a/src/views/MainGameView.vue
+++ b/src/views/MainGameView.vue
@@ -23,8 +23,8 @@
         </button>
       </div>
     </div>
-    <div class="mascot">
-      <mascot-item />
+    <div v-if="mascot.defaultPosition && mascot.showMascot" class="mascot">
+      <mascot-item :quizAppearance="false" />
     </div>
     <div class="modal">
       <div v-if="showModal" class="modal-overlay">
@@ -43,8 +43,10 @@ import { useRouter } from 'vue-router'
 import { ref } from 'vue'
 import MascotItem from '@/components/MascotItem.vue'
 import { useStageNavigator } from '@/composables/useNavigation'
+import { useMascotStore } from '@/stores/useMascotStore'
 
 const router = useRouter()
+const mascot = useMascotStore()
 
 const { goToNextStage } = useStageNavigator()
 
@@ -116,7 +118,7 @@ button {
 .mascot {
   position: fixed;
   bottom: 20px;
-  right: 5%;
+  right: 1%;
   z-index: 1050;
   opacity: 1;
 }

--- a/src/views/dog/MinigameEquipment.vue
+++ b/src/views/dog/MinigameEquipment.vue
@@ -42,7 +42,7 @@ const { goToNextStage } = useStageNavigator()
 const mascot = useMascotStore()
 
 onMounted(() => {
-  mascot.showMessage('STAGE1_BACKPACK', 1000)
+  mascot.showMessage('STAGE1_BACKPACK')
   solutionImages.value = items.value
     .filter((item) => item.type === 'accepted')
     .map((item) => item.image)


### PR DESCRIPTION
* Remove timeout option in `showMessage()`

* React on end event of mascot speech: 
    - give an optional function as the second argument in `showMessage()`
    - this function is being executed once the reading is done
    - e.g.
 ```mascot.showMessage(`MESSAGE_KEY`, () => doSomethingAfterTheMessageIsRead())```

* Adjust mascot for recap quiz: the mascot component is now used there as well: 
    - therefore the default mascot is hidden and the mascot component with other css properties is shown 
    - the third argument in `showMessage()` controls whether the alternative css properties are used

* Implement new speech bubble design

* get a mascot message string by key 
     - Use `mascot.getMessageString(key: StringResourceKey)`
* Closes #72
* Closes #73 