### PR TITLE
118 move scoreboard behind reward card

### DIFF
--- a/src/components/RewardCard.vue
+++ b/src/components/RewardCard.vue
@@ -70,6 +70,7 @@ const handleDropInArea = (item: {
     sound.play(barkSound)
     //TODO: activate when audio is ready
     //mascot.showMessage('REWARD_ROCKY_HAPPY', () => displayNextButton())
+    mascot.hideMascotItem()
     displayNextButton()
   }
 }
@@ -143,6 +144,7 @@ const handleNextButtonClick = () => {
   position: absolute;
   z-index: 100;
   animation: wiggle 1s ease;
+  z-index: 202;
 
   img {
     width: 15vh !important;

--- a/src/components/RewardCard.vue
+++ b/src/components/RewardCard.vue
@@ -68,7 +68,9 @@ const handleDropInArea = (item: {
   if (item.type === 'accepted') {
     wasBoneGiven.value = true
     sound.play(barkSound)
-    mascot.showMessage('REWARD_ROCKY_HAPPY', () => displayNextButton())
+    //TODO: activate when audio is ready
+    //mascot.showMessage('REWARD_ROCKY_HAPPY', () => displayNextButton())
+    displayNextButton()
   }
 }
 
@@ -89,7 +91,7 @@ const handleNextButtonClick = () => {
   position: absolute;
   background-color: var(--s40-color-contrast);
   box-shadow: rgba(0, 0, 0, 0.171) 10px 10px 10px;
-  width: 95%;
+  width: 99%;
   height: 90%;
   border-radius: 20px;
   display: flex;
@@ -97,6 +99,7 @@ const handleNextButtonClick = () => {
   justify-content: space-between;
   color: var(--s40-color-primary);
   margin-top: 40px;
+  z-index: 200;
 }
 
 .solution {
@@ -111,6 +114,7 @@ const handleNextButtonClick = () => {
   border-radius: 20px;
   justify-content: space-around;
   padding-bottom: 20px;
+  z-index: 201;
 }
 
 .solution-images {
@@ -122,16 +126,17 @@ const handleNextButtonClick = () => {
   gap: 40px;
   flex-wrap: wrap;
   height: 40%;
+  z-index: 201;
 }
 
 .solution-image {
-  width: 10%;
+  height: 80px;
 }
 
 .dogImg {
   position: relative;
   top: 0;
-  z-index: 1;
+  z-index: 201;
 }
 
 .boneImg {
@@ -156,6 +161,7 @@ const handleNextButtonClick = () => {
   border: none;
   margin-bottom: 20px;
   color: white;
+  z-index: 201;
 }
 
 .drop-area-container {

--- a/src/components/RewardCard.vue
+++ b/src/components/RewardCard.vue
@@ -91,7 +91,7 @@ const handleNextButtonClick = () => {
   position: absolute;
   background-color: var(--s40-color-contrast);
   box-shadow: rgba(0, 0, 0, 0.171) 10px 10px 10px;
-  width: 99%;
+  width: calc(100% - 2 * 20px);
   height: 90%;
   border-radius: 20px;
   display: flex;

--- a/src/views/dog/MinigameEquipment.vue
+++ b/src/views/dog/MinigameEquipment.vue
@@ -113,24 +113,26 @@ const handleDropInArea = (item: {
   type: 'accepted' | 'rejected'
   message: string
 }) => {
+  let TIME = 0
   if (item.type === 'accepted') {
     collectItem(item.id)
     sound.play(correctSound)
     //TODO: clean up by using message from item
     if (item.id === 1) {
       mascot.showMessage('STAGE1_BONE')
-    }
-    if (item.id === 2) {
+      TIME = 10000
+    } else if (item.id === 2) {
       mascot.showMessage('STAGE1_FEEDING_BOWL')
-    }
-    if (item.id === 3) {
+      TIME = 8000
+    } else if (item.id === 3) {
+      TIME = 6000
       mascot.showMessage('STAGE1_BALL')
     }
 
     if (checkAllAcceptedItemsRemoved()) {
       setTimeout(() => {
         showReward.value = true
-      }, 4000)
+      }, TIME)
     }
   } else {
     sound.play(wrongSound)


### PR DESCRIPTION
- move scoreboard behind reward card
- adjust reward card size
- adjust solution images sizes
- add timeout to equipment minigame at the end of the game to prevent cutting off audio by reward card
- hide mascott when bone was given -> audio is not from ph