### PR TITLE
Avoid context menu after long press on iOS

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -77,6 +77,7 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-touch-callout: none;
 
   background: linear-gradient(to bottom, #f2f5f8, #dadfff);
 
@@ -109,7 +110,12 @@ body {
   }
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: 'Poppins', sans-serif;
   font-weight: 600;
 }


### PR DESCRIPTION
It is done through CSS: ```-webkit-touch-callout: none;```
It works on iPads to avoid the context menu. However, according to mdn it should not be used: 

> Non-standard: This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.

> Non-standard. Check cross-browser support before using.

https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout

Should we use it or could it lead to problems on other platforms?